### PR TITLE
fix: include src folder in release paths

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,7 +22,7 @@
         "LICENSE",
         "README.md",
         "binding_generator",
-        "src/api",
+        "src",
         "build.zig",
         "build.zig.zon",
         "vendor",


### PR DESCRIPTION
I always miss the paths in `build.zon` 🙃 