### PR TITLE
feat: add documentation build target and publish to GitHub pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,47 @@
+name: Deploy Documentation to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+
+      - name: Build documentation
+        run: zig build docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./zig-out/docs/"
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/build.zig
+++ b/build.zig
@@ -116,8 +116,16 @@ pub fn build(b: *std.Build) !void {
         .name = "godot",
         .root_module = godot_module,
     });
-
     b.installArtifact(lib);
+
+    // Docs
+    const docs = b.addInstallDirectory(.{
+        .source_dir = lib.getEmittedDocs(),
+        .install_dir = .prefix,
+        .install_subdir = "docs",
+    });
+    const docs_step = b.step("docs", "Install docs into zig-out/docs");
+    docs_step.dependOn(&docs.step);
 }
 
 const BindgenOutput = struct {


### PR DESCRIPTION
I tried for a couple of hours to get this to generate the docs for the generated Godot builtins/classes (resulting in #23, which I thought would help). I'm starting to think I'm dealing with a bug in the Zig docs generation.

anyways, this generates some documentation, and we can try to loop back later and figure out the rest.

you'll have to tweak some settings on the repo to allow GitHub pages/actions for this to run