### PR TITLE
feature: Variant as struct with tag and data union

### DIFF
--- a/bindgen/codegen.zig
+++ b/bindgen/codegen.zig
@@ -595,14 +595,14 @@ fn generateProc(w: *Writer, fn_node: anytype, class_name: []const u8, func_name:
         , .{args.items.len - 1});
         for (0..args.items.len - 1) |i| {
             if (util.isStringType(arg_types.items[i])) {
-                try w.printLine("args[{d}] = &godot.Variant.initFrom(godot.core.String.initFromLatin1Chars({s}));", .{ i, args.items[i] });
+                try w.printLine("args[{d}] = &godot.Variant.init(godot.core.String.initFromLatin1Chars({s}));", .{ i, args.items[i] });
             } else {
-                try w.printLine("args[{d}] = &godot.Variant.initFrom({s});", .{ i, args.items[i] });
+                try w.printLine("args[{d}] = &godot.Variant.init({s});", .{ i, args.items[i] });
             }
         }
         try w.printLine(
             \\inline for(fields, 0..)|f, i|{{
-            \\    args[{d}+i] = &godot.Variant.initFrom(@field(varargs, f.name));
+            \\    args[{d}+i] = &godot.Variant.init(@field(varargs, f.name));
             \\}}
         , .{args.items.len - 1});
 
@@ -659,7 +659,7 @@ fn generateProc(w: *Writer, fn_node: anytype, class_name: []const u8, func_name:
                 if (std.mem.eql(u8, return_type, "Variant")) {
                     try w.printLine("godot.core.objectMethodBindCall(method, {s}, @ptrCast(@alignCast(&args[0])), args.len, &result, &err);", .{self_ptr});
                 } else {
-                    try w.writeLine("var ret:Variant = Variant.init();");
+                    try w.writeLine("var ret: Variant = .nil;");
                     try w.printLine("godot.core.objectMethodBindCall(method, {s}, @ptrCast(@alignCast(&args[0])), args.len, &ret, &err);", .{self_ptr});
                     if (need_return) {
                         try w.printLine("result = ret.as({s});", .{return_type});
@@ -790,8 +790,6 @@ fn generateCore(ctx: *Context) !void {
             }
         }
 
-        try w.writeLine("godot.Variant.initBindings();");
-
         for (ctx.all_engine_classes.items) |cls| {
             try w.printLine("godot.getClassName({0s}).* = godot.core.StringName.initFromLatin1Chars(\"{0s}\");", .{cls});
         }
@@ -840,7 +838,7 @@ fn generateImports(w: *Writer, imports: *const Imports) !void {
         if (std.mem.startsWith(u8, import.*, "Vector")) {
             try w.printLine("const {0s} = @import(\"vector\").{0s};", .{import.*});
         } else if (std.mem.eql(u8, import.*, "Variant")) {
-            try w.writeLine("const Variant = @import(\"../Variant.zig\");");
+            try w.writeLine("const Variant = @import(\"../Variant.zig\").Variant;");
         } else if (std.mem.eql(u8, import.*, "global")) {
             try w.writeLine("const global = @import(\"global.zig\");");
         } else {

--- a/bindgen/context/Enum.zig
+++ b/bindgen/context/Enum.zig
@@ -39,7 +39,7 @@ pub const Value = struct {
 
     pub fn fromGlobalEnum(allocator: Allocator, api: GodotApi.GlobalEnum.Value) !Value {
         const doc = if (api.description) |desc| try allocator.dupe(u8, desc) else null;
-        errdefer allocator.free(doc orelse &.{});
+        errdefer allocator.free(doc orelse "");
 
         const name = try case.allocTo(allocator, .snake, api.name);
         errdefer allocator.free(name);

--- a/bindgen/context/Flag.zig
+++ b/bindgen/context/Flag.zig
@@ -81,7 +81,7 @@ pub const Field = struct {
 
     pub fn fromGlobalEnum(allocator: Allocator, api: GodotApi.GlobalEnum.Value, default: i64) !Field {
         const doc = if (api.description) |desc| try allocator.dupe(u8, desc) else null;
-        errdefer allocator.free(doc orelse &.{});
+        errdefer allocator.free(doc orelse "");
 
         const name = try case.allocTo(allocator, .snake, api.name);
         errdefer allocator.free(name);
@@ -106,7 +106,7 @@ pub const Const = struct {
 
     pub fn fromGlobalEnum(allocator: Allocator, api: GodotApi.GlobalEnum.Value) !Const {
         const doc = if (api.description) |desc| try allocator.dupe(u8, desc) else null;
-        errdefer allocator.free(doc orelse &.{});
+        errdefer allocator.free(doc orelse "");
 
         const name = try case.allocTo(allocator, .snake, api.name);
         errdefer allocator.free(name);

--- a/bindgen/context/Function.zig
+++ b/bindgen/context/Function.zig
@@ -15,7 +15,7 @@ is_vararg: bool,
 
 pub fn fromUtilityFunction(allocator: Allocator, function: GodotApi.UtilityFunction) !Function {
     const doc = if (function.description) |desc| try allocator.dupe(u8, desc) else null;
-    errdefer allocator.free(doc orelse &.{});
+    errdefer allocator.free(doc orelse "");
 
     const name = try case.allocTo(allocator, .camel, function.name);
     errdefer allocator.free(name);
@@ -48,7 +48,7 @@ pub fn fromUtilityFunction(allocator: Allocator, function: GodotApi.UtilityFunct
 }
 
 pub fn deinit(self: *Function, allocator: Allocator) void {
-    allocator.free(self.doc orelse &.{});
+    allocator.free(self.doc orelse "");
     allocator.free(self.name);
     for (self.parameters) |param| {
         param.deinit(allocator);

--- a/src/Variant.zig
+++ b/src/Variant.zig
@@ -1,203 +1,277 @@
-const std = @import("std");
+pub const ObjectId = enum(u64) { _ };
 
-const godot = @import("root.zig");
-
-const Variant = @This();
-
-const precision = @import("build_options").precision;
-const size = if (std.mem.eql(u8, precision, "double")) 40 else 24;
-
-value: [size]u8,
-
-const Type = c_int;
-const TYPE_NIL: c_int = 0;
-const TYPE_BOOL: c_int = 1;
-const TYPE_INT: c_int = 2;
-const TYPE_FLOAT: c_int = 3;
-const TYPE_STRING: c_int = 4;
-const TYPE_VECTOR2: c_int = 5;
-const TYPE_VECTOR2I: c_int = 6;
-const TYPE_RECT2: c_int = 7;
-const TYPE_RECT2I: c_int = 8;
-const TYPE_VECTOR3: c_int = 9;
-const TYPE_VECTOR3I: c_int = 10;
-const TYPE_TRANSFORM2D: c_int = 11;
-const TYPE_VECTOR4: c_int = 12;
-const TYPE_VECTOR4I: c_int = 13;
-const TYPE_PLANE: c_int = 14;
-const TYPE_QUATERNION: c_int = 15;
-const TYPE_AABB: c_int = 16;
-const TYPE_BASIS: c_int = 17;
-const TYPE_TRANSFORM3D: c_int = 18;
-const TYPE_PROJECTION: c_int = 19;
-const TYPE_COLOR: c_int = 20;
-const TYPE_STRING_NAME: c_int = 21;
-const TYPE_NODE_PATH: c_int = 22;
-const TYPE_RID: c_int = 23;
-const TYPE_OBJECT: c_int = 24;
-const TYPE_CALLABLE: c_int = 25;
-const TYPE_SIGNAL: c_int = 26;
-const TYPE_DICTIONARY: c_int = 27;
-const TYPE_ARRAY: c_int = 28;
-const TYPE_PACKED_BYTE_ARRAY: c_int = 29;
-const TYPE_PACKED_INT32_ARRAY: c_int = 30;
-const TYPE_PACKED_INT64_ARRAY: c_int = 31;
-const TYPE_PACKED_FLOAT32_ARRAY: c_int = 32;
-const TYPE_PACKED_FLOAT64_ARRAY: c_int = 33;
-const TYPE_PACKED_STRING_ARRAY: c_int = 34;
-const TYPE_PACKED_VECTOR2_ARRAY: c_int = 35;
-const TYPE_PACKED_VECTOR3_ARRAY: c_int = 36;
-const TYPE_PACKED_COLOR_ARRAY: c_int = 37;
-const TYPE_MAX: c_int = 38;
-const Operator = c_int;
-const OP_EQUAL: c_int = 0;
-const OP_NOT_EQUAL: c_int = 1;
-const OP_LESS: c_int = 2;
-const OP_LESS_EQUAL: c_int = 3;
-const OP_GREATER: c_int = 4;
-const OP_GREATER_EQUAL: c_int = 5;
-const OP_ADD: c_int = 6;
-const OP_SUBTRACT: c_int = 7;
-const OP_MULTIPLY: c_int = 8;
-const OP_DIVIDE: c_int = 9;
-const OP_NEGATE: c_int = 10;
-const OP_POSITIVE: c_int = 11;
-const OP_MODULE: c_int = 12;
-const OP_POWER: c_int = 13;
-const OP_SHIFT_LEFT: c_int = 14;
-const OP_SHIFT_RIGHT: c_int = 15;
-const OP_BIT_AND: c_int = 16;
-const OP_BIT_OR: c_int = 17;
-const OP_BIT_XOR: c_int = 18;
-const OP_BIT_NEGATE: c_int = 19;
-const OP_AND: c_int = 20;
-const OP_OR: c_int = 21;
-const OP_XOR: c_int = 22;
-const OP_NOT: c_int = 23;
-const OP_IN: c_int = 24;
-const OP_MAX: c_int = 25;
-
-var from_type: [@as(usize, godot.c.GDEXTENSION_VARIANT_TYPE_VARIANT_MAX)]godot.c.GDExtensionVariantFromTypeConstructorFunc = undefined;
-var to_type: [@as(usize, godot.c.GDEXTENSION_VARIANT_TYPE_VARIANT_MAX)]godot.c.GDExtensionTypeFromVariantConstructorFunc = undefined;
-
-pub fn initBindings() void {
-    for (1..TYPE_MAX) |i| {
-        from_type[i] = godot.core.getVariantFromTypeConstructor(@intCast(i));
-        to_type[i] = godot.core.getVariantToTypeConstructor(@intCast(i));
-    }
-}
-
-fn getByGodotType(comptime T: type) Type {
-    return switch (T) {
-        godot.core.AABB => godot.c.GDEXTENSION_VARIANT_TYPE_AABB,
-        godot.core.Basis => godot.c.GDEXTENSION_VARIANT_TYPE_BASIS,
-        godot.core.Plane => godot.c.GDEXTENSION_VARIANT_TYPE_PLANE,
-        godot.core.Projection => godot.c.GDEXTENSION_VARIANT_TYPE_PROJECTION,
-        godot.core.Quaternion => godot.c.GDEXTENSION_VARIANT_TYPE_QUATERNION,
-        godot.core.Rect2 => godot.c.GDEXTENSION_VARIANT_TYPE_RECT2,
-        godot.core.Rect2i => godot.c.GDEXTENSION_VARIANT_TYPE_RECT2I,
-        godot.core.String => godot.c.GDEXTENSION_VARIANT_TYPE_STRING,
-        godot.core.Transform2D => godot.c.GDEXTENSION_VARIANT_TYPE_TRANSFORM2D,
-        godot.core.Transform3D => godot.c.GDEXTENSION_VARIANT_TYPE_TRANSFORM3D,
-        godot.Vector2 => godot.c.GDEXTENSION_VARIANT_TYPE_VECTOR2,
-        godot.Vector2i => godot.c.GDEXTENSION_VARIANT_TYPE_VECTOR2I,
-        godot.Vector3 => godot.c.GDEXTENSION_VARIANT_TYPE_VECTOR3,
-        godot.Vector3i => godot.c.GDEXTENSION_VARIANT_TYPE_VECTOR3I,
-        godot.Vector4 => godot.c.GDEXTENSION_VARIANT_TYPE_VECTOR4,
-        godot.Vector4i => godot.c.GDEXTENSION_VARIANT_TYPE_VECTOR4I,
-
-        godot.core.Array => godot.c.GDEXTENSION_VARIANT_TYPE_ARRAY,
-        godot.core.Callable => godot.c.GDEXTENSION_VARIANT_TYPE_CALLABLE,
-        godot.core.Color => godot.c.GDEXTENSION_VARIANT_TYPE_COLOR,
-        godot.core.Dictionary => godot.c.GDEXTENSION_VARIANT_TYPE_DICTIONARY,
-        godot.core.NodePath => godot.c.GDEXTENSION_VARIANT_TYPE_NODE_PATH,
-        godot.core.Object => godot.c.GDEXTENSION_VARIANT_TYPE_OBJECT,
-        godot.core.RID => godot.c.GDEXTENSION_VARIANT_TYPE_RID,
-        godot.core.Signal => godot.c.GDEXTENSION_VARIANT_TYPE_SIGNAL,
-        godot.core.StringName => godot.c.GDEXTENSION_VARIANT_TYPE_STRING_NAME,
-
-        godot.core.PackedByteArray => godot.c.GDEXTENSION_VARIANT_TYPE_PACKED_BYTE_ARRAY,
-        godot.core.PackedColorArray => godot.c.GDEXTENSION_VARIANT_TYPE_PACKED_COLOR_ARRAY,
-        godot.core.PackedFloat32Array => godot.c.GDEXTENSION_VARIANT_TYPE_PACKED_FLOAT32_ARRAY,
-        godot.core.PackedFloat64Array => godot.c.GDEXTENSION_VARIANT_TYPE_PACKED_FLOAT64_ARRAY,
-        godot.core.PackedInt32Array => godot.c.GDEXTENSION_VARIANT_TYPE_PACKED_INT32_ARRAY,
-        godot.core.PackedInt64Array => godot.c.GDEXTENSION_VARIANT_TYPE_PACKED_INT64_ARRAY,
-        godot.core.PackedStringArray => godot.c.GDEXTENSION_VARIANT_TYPE_PACKED_STRING_ARRAY,
-        godot.core.PackedVector2Array => godot.c.GDEXTENSION_VARIANT_TYPE_PACKED_VECTOR2_ARRAY,
-        godot.core.PackedVector3Array => godot.c.GDEXTENSION_VARIANT_TYPE_PACKED_VECTOR3_ARRAY,
-        else => godot.c.GDEXTENSION_VARIANT_TYPE_NIL,
-    };
-}
-
-fn getChildTypeOrSelf(comptime T: type) type {
-    const typeInfo = @typeInfo(T);
-    return switch (typeInfo) {
-        .pointer => |info| info.child,
-        .optional => |info| info.child,
-        else => T,
-    };
-}
-
-pub fn getVariantType(comptime T: type) Type {
-    const typeInfo = @typeInfo(T);
-    if (typeInfo == .pointer and @typeInfo(typeInfo.pointer.child) != .@"struct") {
-        @compileError("Init Variant from " ++ @typeName(T) ++ " is not supported");
-    }
-    const RT = getChildTypeOrSelf(T);
-
-    const ret = comptime getByGodotType(RT);
-    if (ret == godot.c.GDEXTENSION_VARIANT_TYPE_NIL) {
-        const ret1 = switch (@typeInfo(RT)) {
-            .@"struct" => godot.c.GDEXTENSION_VARIANT_TYPE_OBJECT,
-            .bool => godot.c.GDEXTENSION_VARIANT_TYPE_BOOL,
-            .int, .@"enum", .comptime_int => godot.c.GDEXTENSION_VARIANT_TYPE_INT,
-            .float, .comptime_float => godot.c.GDEXTENSION_VARIANT_TYPE_FLOAT,
-            .void => godot.c.GDEXTENSION_VARIANT_TYPE_NIL,
-            else => @compileError("Cannot construct variant from " ++ @typeName(T)),
-        };
-        return ret1;
-    }
-    return ret;
-}
-
-pub fn init() Variant {
-    var result: Variant = undefined;
-    godot.core.variantNewNil(&result);
-    return result;
-}
-
-pub fn deinit(self: *Variant) void {
-    godot.core.variantDestroy(&self.value);
-}
-
-pub fn initFrom(from: anytype) Variant {
-    if (@TypeOf(from) == Variant) return from;
-    const tid = comptime getVariantType(@TypeOf(from));
-    var result: Variant = undefined;
-    from_type[@intCast(tid)].?(@ptrCast(&result), @ptrCast(@constCast(&from)));
-    return result;
-}
-
-pub fn as(self_const: Variant, comptime T: type) T {
-    // Godot wants a mutable pointer. I don't think it actually needs one, but just to be safe we'll copy.
-    var self = self_const;
-
-    const tid = comptime getVariantType(T);
-    if (tid == godot.c.GDEXTENSION_VARIANT_TYPE_OBJECT) {
-        var obj: ?*anyopaque = null;
-        to_type[godot.c.GDEXTENSION_VARIANT_TYPE_OBJECT].?(@ptrCast(&obj), @ptrCast(&self.value));
-        const godotObj: *godot.core.Object = @ptrCast(@alignCast(godot.core.objectGetInstanceBinding(obj, godot.core.p_library, null)));
-        const RealType = @typeInfo(T).pointer.child;
-        if (RealType == godot.core.Object) {
-            return godotObj;
-        } else {
-            const classTag = godot.classdbGetClassTag(@ptrCast(godot.getClassName(RealType)));
-            const casted = godot.objectCastTo(godotObj.godot_object, classTag);
-            return @ptrCast(@alignCast(godot.objectGetInstanceBinding(casted, godot.core.p_library, null)));
+pub const Variant = extern struct {
+    comptime {
+        const expected = if (std.mem.eql(u8, precision, "double")) 40 else 24;
+        const actual = @sizeOf(Variant);
+        if (expected != actual) {
+            const message = std.fmt.comptimePrint("Expected Variant to be {d} bytes, but it is {d}", .{ expected, actual });
+            @compileError(message);
         }
     }
 
-    var result: T = undefined;
-    to_type[@intCast(tid)].?(@ptrCast(&result), @ptrCast(@constCast(&self.value)));
-    return result;
-}
+    pub const nil: Variant = .{ .tag = .nil, .data = .{ .nil = {} } };
+
+    tag: Tag align(8),
+    data: Data align(8),
+
+    pub fn init(value: anytype) Variant {
+        const constructor = bindVariantFrom(Tag.forType(@TypeOf(value)));
+        var result: Variant = undefined;
+        constructor(@ptrCast(&result), @ptrCast(@constCast(&value)));
+        return result;
+    }
+
+    pub fn deinit(self: *Variant) void {
+        variantDestroy(@ptrCast(&self));
+    }
+
+    pub fn as(self: Variant, comptime T: type) T {
+        const tag = comptime Tag.forType(T);
+
+        if (tag == .object) {
+            var ptr: ?*anyopaque = null;
+
+            const variantTo = bindVariantTo(tag);
+            variantTo(@ptrCast(&ptr), @ptrCast(@constCast(&self)));
+
+            // TODO: GDExtensionInstanceBindingCallbacks?
+            const instance: *Object = @ptrCast(@alignCast(objectGetInstanceBinding(ptr, p_library, null)));
+
+            if (meta.Child(T) == Object) {
+                return instance;
+            } else {
+                const class_name = godot.getClassName(meta.Child(T));
+                const class_tag = classdbGetClassTag(@ptrCast(class_name));
+                // TODO: this can return null if its not the right type; return type should be optional depending on T, right? or return error?
+                const casted = objectCastTo(instance.godot_object, class_tag);
+                const binding = objectGetInstanceBinding(casted, p_library, null);
+
+                return @ptrCast(@alignCast(binding));
+            }
+        } else {
+            var result: T = undefined;
+            const variantTo = bindVariantTo(tag);
+            variantTo(@ptrCast(&result), @ptrCast(@constCast(&self)));
+            return result;
+        }
+    }
+
+    pub const Tag = enum(u32) {
+        aabb = 16,
+        array = 28,
+        basis = 17,
+        bool = 1,
+        callable = 25,
+        color = 20,
+        dictionary = 27,
+        float = 3,
+        int = 2,
+        nil = 0,
+        node_path = 22,
+        object = 24,
+        packed_byte_array = 29,
+        packed_color_array = 37,
+        packed_float32_array = 32,
+        packed_float64_array = 33,
+        packed_int32_array = 30,
+        packed_int64_array = 31,
+        packed_string_array = 34,
+        packed_vector2_array = 35,
+        packed_vector3_array = 36,
+        plane = 14,
+        projection = 19,
+        quaternion = 15,
+        rect2 = 7,
+        rect2i = 8,
+        rid = 23,
+        signal = 26,
+        string = 4,
+        string_name = 21,
+        transform2d = 11,
+        transform3d = 18,
+        vector2 = 5,
+        vector2i = 6,
+        vector3 = 9,
+        vector3i = 10,
+        vector4 = 12,
+        vector4i = 13,
+
+        pub fn forValue(value: anytype) Variant.Tag {
+            return forType(@TypeOf(value));
+        }
+
+        pub fn forType(comptime T: type) Variant.Tag {
+            return switch (T) {
+                AABB => .aabb,
+                Array => .array,
+                Basis => .basis,
+                Callable => .callable,
+                Color => .color,
+                Dictionary => .dictionary,
+                NodePath => .node_path,
+                Object => .object,
+                PackedByteArray => .packed_byte_array,
+                PackedColorArray => .packed_color_array,
+                PackedFloat32Array => .packed_float32_array,
+                PackedFloat64Array => .packed_float64_array,
+                PackedInt32Array => .packed_int32_array,
+                PackedInt64Array => .packed_int64_array,
+                PackedStringArray => .packed_string_array,
+                PackedVector2Array => .packed_vector2_array,
+                PackedVector3Array => .packed_vector3_array,
+                Plane => .plane,
+                Projection => .projection,
+                Quaternion => .quaternion,
+                RID => .rid,
+                Rect2 => .rect2,
+                Rect2i => .rect2i,
+                Signal => .signal,
+                String => .string,
+                StringName => .string_name,
+                Transform2D => .transform2d,
+                Transform3D => .transform3d,
+                Vector2 => .vector2,
+                Vector2i => .vector2i,
+                Vector3 => .vector3,
+                Vector3i => .vector3i,
+                Vector4 => .vector4,
+                Vector4i => .vector4i,
+                inline else => |U| switch (@typeInfo(U)) {
+                    .void => .nil,
+                    .bool => .bool,
+                    .int, .@"enum", .comptime_int => .int,
+                    .float, .comptime_float => .float,
+                    .@"struct" => |i| if (i.backing_integer) .int else .object,
+                    else => @compileError("Cannot construct variant from " ++ @typeName(T)),
+                },
+            };
+        }
+    };
+
+    pub const Data = extern union {
+        aabb: *AABB,
+        array: *Array,
+        basis: *Basis,
+        bool: bool,
+        callable: Callable,
+        color: Color,
+        dictionary: *Dictionary,
+        float: if (mem.eql(u8, precision, "double")) f64 else f32,
+        int: i64,
+        nil: void,
+        node_path: NodePath,
+        object: extern struct { id: ObjectId, object: *Object },
+        packed_byte_array: extern struct { refs: Atomic(u32), array: *PackedByteArray },
+        packed_color_array: extern struct { refs: Atomic(u32), array: *PackedColorArray },
+        packed_float32_array: extern struct { refs: Atomic(u32), array: *PackedFloat32Array },
+        packed_float64_array: extern struct { refs: Atomic(u32), array: *PackedFloat64Array },
+        packed_int32_array: extern struct { refs: Atomic(u32), array: *PackedInt32Array },
+        packed_int64_array: extern struct { refs: Atomic(u32), array: *PackedInt64Array },
+        packed_string_array: extern struct { refs: Atomic(u32), array: *PackedStringArray },
+        packed_vector2_array: extern struct { refs: Atomic(u32), array: *PackedVector2Array },
+        packed_vector3_array: extern struct { refs: Atomic(u32), array: *PackedVector3Array },
+        plane: Plane,
+        projection: *Projection,
+        quaternion: Quaternion,
+        rect2: Rect2,
+        rect2i: Rect2i,
+        rid: RID,
+        signal: Signal,
+        string: String,
+        string_name: StringName,
+        transform2d: *Transform2D,
+        transform3d: *Transform3D,
+        vector2: Vector2,
+        vector2i: Vector2i,
+        vector3: Vector3,
+        vector3i: Vector3i,
+        vector4: Vector4,
+        vector4i: Vector4i,
+        // max = 38,
+    };
+
+    pub const Operator = enum(u32) {
+        equal = 0,
+        not_equal = 1,
+        less = 2,
+        less_equal = 3,
+        greater = 4,
+        greater_equal = 5,
+        add = 6,
+        subtract = 7,
+        multiply = 8,
+        divide = 9,
+        negate = 10,
+        positive = 11,
+        module = 12,
+        power = 13,
+        shift_left = 14,
+        shift_right = 15,
+        bit_and = 16,
+        bit_or = 17,
+        bit_xor = 18,
+        bit_negate = 19,
+        @"and" = 20,
+        @"or" = 21,
+        xor = 22,
+        not = 23,
+        in = 24,
+        max = 25,
+    };
+};
+
+const std = @import("std");
+const Atomic = std.atomic.Value;
+const mem = std.mem;
+const meta = std.meta;
+
+const precision = @import("build_options").precision;
+
+const gdext = @import("gdextension");
+
+const vector = @import("vector");
+const Vector2 = vector.Vector2;
+const Vector2i = vector.Vector2i;
+const Vector3 = vector.Vector3;
+const Vector3i = vector.Vector3i;
+const Vector4 = vector.Vector4;
+const Vector4i = vector.Vector4i;
+
+const godot = @import("root.zig");
+const AABB = godot.core.AABB;
+const Array = godot.core.Array;
+const Basis = godot.core.Basis;
+const bindVariantFrom = godot.support.bindVariantFrom;
+const bindVariantTo = godot.support.bindVariantTo;
+const Callable = godot.core.Callable;
+const classdbGetClassTag = godot.core.classdbGetClassTag;
+const Color = godot.core.Color;
+const Dictionary = godot.core.Dictionary;
+const NodePath = godot.core.NodePath;
+const Object = godot.core.Object;
+const objectCastTo = godot.core.objectCastTo;
+const objectGetInstanceBinding = godot.core.objectGetInstanceBinding;
+const p_library = godot.core.p_library;
+const PackedByteArray = godot.core.PackedByteArray;
+const PackedColorArray = godot.core.PackedColorArray;
+const PackedFloat32Array = godot.core.PackedFloat32Array;
+const PackedFloat64Array = godot.core.PackedFloat64Array;
+const PackedInt32Array = godot.core.PackedInt32Array;
+const PackedInt64Array = godot.core.PackedInt64Array;
+const PackedStringArray = godot.core.PackedStringArray;
+const PackedVector2Array = godot.core.PackedVector2Array;
+const PackedVector3Array = godot.core.PackedVector3Array;
+const Plane = godot.core.Plane;
+const Projection = godot.core.Projection;
+const Quaternion = godot.core.Quaternion;
+const Rect2 = godot.core.Rect2;
+const Rect2i = godot.core.Rect2i;
+const RID = godot.core.RID;
+const Signal = godot.core.Signal;
+const String = godot.core.String;
+const StringName = godot.core.StringName;
+const Transform2D = godot.core.Transform2D;
+const Transform3D = godot.core.Transform3D;
+const variantDestroy = godot.core.variantDestroy;
+const variantNewNil = godot.core.variantNewNil;

--- a/src/support.zig
+++ b/src/support.zig
@@ -63,6 +63,26 @@ pub inline fn bindFunction(
     return bind(name, callback);
 }
 
+pub inline fn bindVariantFrom(comptime @"type": godot.Variant.Tag) VariantFrom {
+    const callback = struct {
+        fn callback() VariantFrom {
+            return core.getVariantFromTypeConstructor(@intFromEnum(@"type")).?;
+        }
+    }.callback;
+
+    return bind(null, callback);
+}
+
+pub inline fn bindVariantTo(comptime @"type": godot.Variant.Tag) VariantTo {
+    const callback = struct {
+        fn callback() VariantTo {
+            return core.getVariantToTypeConstructor(@intFromEnum(@"type")).?;
+        }
+    }.callback;
+
+    return bind(null, callback);
+}
+
 inline fn bind(
     comptime name: ?[]const u8,
     comptime callback: anytype,
@@ -100,3 +120,5 @@ const ClassMethod = Child(c.GDExtensionMethodBindPtr);
 const Constructor = Child(c.GDExtensionPtrConstructor);
 const Destructor = Child(c.GDExtensionPtrDestructor);
 const Function = Child(c.GDExtensionPtrUtilityFunction);
+const VariantFrom = Child(c.GDExtensionVariantFromTypeConstructorFunc);
+const VariantTo = Child(c.GDExtensionTypeFromVariantConstructorFunc);


### PR DESCRIPTION
I was really hoping we could use an actual tagged union, but the memory layout is unspecified so we have to settle for this approach.

still much better than the opaque data structure as before.

this also fixes a bug I think I introduced in earlier commits that was causing the signals to crash the example project.